### PR TITLE
fix empty description

### DIFF
--- a/src/objects/responses.js
+++ b/src/objects/responses.js
@@ -8,7 +8,8 @@ function parse(responses) {
     res.push('| ---- | ----------- |') 
 
     Object.keys(responses).map(response => {
-        res.push(`| ${response} | ${responses[response].description.replace(/[\r\n]/g, ' ') || ''} |`) 
+        let desc = responses[response] && responses[response].description || '';
+        res.push(`| ${response} | ${desc.replace(/[\r\n]/g, ' ') || ''} |`) 
     }) 
     return res.join('\n') 
 }


### PR DESCRIPTION
Fix Empty Description.

```bash
TypeError: Cannot read property 'replace' of undefined
    at Object.keys.map.response (/usr/local/lib/node_modules/swagger-to-slate/src/objects/responses.js:11:68)
    at Array.map (native)
    at Object.parse (/usr/local/lib/node_modules/swagger-to-slate/src/objects/responses.js:10:28)
    at Object.keys.map.method (/usr/local/lib/node_modules/swagger-to-slate/src/objects/path.js:52:33)
    at Array.map (native)
    at Object.parse (/usr/local/lib/node_modules/swagger-to-slate/src/objects/path.js:24:23)
    at Object.keys.map.path (/usr/local/lib/node_modules/swagger-to-slate/src/convert.js:54:45)
    at Array.map (native)
    at convertToMd (/usr/local/lib/node_modules/swagger-to-slate/src/convert.js:53:45)
    at Object.<anonymous> (/usr/local/lib/node_modules/swagger-to-slate/index.js:46:5)
```